### PR TITLE
New scenarios added

### DIFF
--- a/src/main/java/com/selenium/training/pages/ArticlePage.java
+++ b/src/main/java/com/selenium/training/pages/ArticlePage.java
@@ -3,6 +3,8 @@ package com.selenium.training.pages;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.testng.Assert;
 
 public class ArticlePage extends BasePage{
 
@@ -13,7 +15,19 @@ public class ArticlePage extends BasePage{
     @FindBy(id = "firstHeading")
     private WebElement pageTitle;
 
+    @FindBy(id = "ca-talk")
+    private WebElement talkTab;
+
     public String getPageTitle(){
         return pageTitle.getText();
+    }
+
+    public String getTabText(){
+        return talkTab.getText();
+    }
+
+    public TalkPage clickOnTalkTab(){
+        talkTab.click();
+        return new TalkPage(getWebDriver());
     }
 }

--- a/src/main/java/com/selenium/training/pages/ArticlePage.java
+++ b/src/main/java/com/selenium/training/pages/ArticlePage.java
@@ -3,8 +3,6 @@ package com.selenium.training.pages;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.testng.Assert;
 
 public class ArticlePage extends BasePage{
 

--- a/src/main/java/com/selenium/training/pages/TalkPage.java
+++ b/src/main/java/com/selenium/training/pages/TalkPage.java
@@ -1,0 +1,18 @@
+package com.selenium.training.pages;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+public class TalkPage extends BasePage{
+    public TalkPage(WebDriver webDriver) {
+        super(webDriver);
+    }
+
+    @FindBy(id = "firstHeading")
+    private WebElement pageTitle;
+
+    public String getPageTitle(){
+        return pageTitle.getText();
+    }
+}

--- a/src/main/java/com/selenium/training/pages/WikiHomePage.java
+++ b/src/main/java/com/selenium/training/pages/WikiHomePage.java
@@ -1,9 +1,13 @@
 package com.selenium.training.pages;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class WikiHomePage extends BasePage{
 
@@ -18,10 +22,18 @@ public class WikiHomePage extends BasePage{
     @FindBy(className = "pure-button-primary-progressive")
     private WebElement searchButton;
 
+    @FindBy(className = "link-box")
+    private List<WebElement> languageLinks;
+
     public ArticlePage search(String text){
         searchInput.sendKeys(text);
         getWebDriverWait().until(ExpectedConditions.elementToBeClickable(searchButton));
         searchButton.click();
         return new ArticlePage(getWebDriver());
+    }
+
+    public boolean isAllLanguages(List<String> expectedLanguages){
+        List<String> languageLinkTexts = languageLinks.stream().map(x -> x.findElement(By.cssSelector("strong")).getText()).collect(Collectors.toList());
+        return languageLinkTexts.containsAll(expectedLanguages);
     }
 }

--- a/src/test/java/hellocucumber/features/wikipedia_home_page.feature
+++ b/src/test/java/hellocucumber/features/wikipedia_home_page.feature
@@ -1,13 +1,31 @@
 Feature: Wikipedia Home Page
   Validation on the Wiki Home Page
 
+  Scenario: Check languages
+    Given I'm in the wikipedia home page
+    Then I should see the language links
+      | English   |
+      | Deutsch   |
+      | Español   |
+      | Français  |
+      | Italiano  |
+      | Polski    |
+      | Português |
+
   Scenario Outline: Search
     Given I'm in the wikipedia home page
     When I search "<text>"
     Then I should see the article title "<expected>"
 
-  Examples:
-    | text | expected |
-    | Java | Java     |
-    | Java | Aaa      |
-    | Java | Java     |
+    Examples:
+      | text | expected |
+      | Java | Java     |
+      | Java | Java     |
+      | Java | Java     |
+
+  Scenario: Check Talk Tab title
+    Given I'm in the wikipedia home page
+    When I search "Java"
+    Then I should see the "Talk" tab
+    When I click on the Talk tab
+    Then I should see the "Talk:Java" title

--- a/src/test/java/hellocucumber/stepDefinitions/StepDefinitions.java
+++ b/src/test/java/hellocucumber/stepDefinitions/StepDefinitions.java
@@ -2,6 +2,7 @@ package hellocucumber.stepDefinitions;
 
 import com.selenium.training.MyDriver;
 import com.selenium.training.pages.ArticlePage;
+import com.selenium.training.pages.TalkPage;
 import com.selenium.training.pages.WikiHomePage;
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
@@ -14,26 +15,49 @@ import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Parameters;
 
+import java.util.List;
+
 public class StepDefinitions {
 
     private WikiHomePage wikiHomePage;
     private ArticlePage articlePage;
+    private TalkPage talkPage;
 
     MyDriver myDriver;
 
     @Given("I'm in the wikipedia home page")
-    public void today_is_Sunday() {
+    public void todayIsSunday() {
         wikiHomePage = new WikiHomePage(myDriver.getWebDriver());
     }
 
+    @Then("I should see the language links")
+    public void iShouldSeeTheLanguageLinks(List<String> languages) {
+        Assert.assertTrue(wikiHomePage.isAllLanguages(languages));
+    }
+
     @When("I search {string}")
-    public void i_ask_whether_it_s_Friday_yet(String text) {
+    public void iAskWhetherItsFridayYet(String text) {
         articlePage = wikiHomePage.search(text);
     }
 
     @Then("I should see the article title {string}")
-    public void i_should_be_told(String text) {
+    public void iShouldBeTold(String text) {
         Assert.assertEquals(articlePage.getPageTitle(), text);
+    }
+
+    @Then("I should see the {string} tab")
+    public void iShouldSeeTheTab(String tabName) {
+        Assert.assertEquals(articlePage.getTabText(), tabName);
+    }
+
+    @When("I click on the Talk tab")
+    public void iClickOnTheTalkTab() {
+        talkPage = articlePage.clickOnTalkTab();
+    }
+
+    @Then("I should see the {string} title")
+    public void iShouldSeeTheTitle(String tabTitle) {
+        Assert.assertEquals(talkPage.getPageTitle(), tabTitle);
     }
 
     @Before
@@ -45,4 +69,5 @@ public class StepDefinitions {
     public void afterSuite(){
         wikiHomePage.dispose();
     }
+
 }


### PR DESCRIPTION
## DESCRIPTION
added new scenarios

## PR CHECKLIST
- [x] PR title has description.
- [x] Review Complete.
- [x] All Evidence Attached.

## CONSIDERATIONS

## TESTING INSTRUCTIONS
mvn install
mvn test
## EVIDENCE

<details>
<summary>Click here to see evidence</summary>
<pre>
  -------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running TestSuite
Configuring TestNG with: org.apache.maven.surefire.testng.conf.TestNG652Configurator@7b0070
Feature: Wikipedia Home Page
  Validation on the Wiki Home Page

  Scenario: Check languages               # ./src/test/java/hellocucumber/features/wikipedia_home_page.feature:4
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Starting ChromeDriver 88.0.4324.96 (68dba2d8a0b149a1d3afac56fa74648032bcf46b-refs/branch-heads/4324@{#1784}) on port 19630
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
Feb 26, 2021 3:39:36 PM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
    Given I am in the wikipedia home page # WikipediaStepDefinitions.iAmInTheWikipediaHomePage()
    Then I should see the language links  # WikipediaStepDefinitions.iShouldSeeTheLanguageLinks(String>)

  Scenario Outline: Search # ./src/test/java/hellocucumber/features/wikipedia_home_page.feature:15
    Given I am in the wikipedia home page
    When I search "<text>"
    Then I should see the article title "<expected>"

    Examples:

  Scenario Outline: Search                     # ./src/test/java/hellocucumber/features/wikipedia_home_page.feature:22
Starting ChromeDriver 88.0.4324.96 (68dba2d8a0b149a1d3afac56fa74648032bcf46b-refs/branch-heads/4324@{#1784}) on port 47221
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
Feb 26, 2021 3:39:41 PM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
    Given I am in the wikipedia home page      # WikipediaStepDefinitions.iAmInTheWikipediaHomePage()
    When I search "Java"                       # WikipediaStepDefinitions.iAskWhetherItsFridayYet(String)
    Then I should see the article title "Java" # WikipediaStepDefinitions.iShouldBeTold(String)

  Scenario Outline: Search                     # ./src/test/java/hellocucumber/features/wikipedia_home_page.feature:23
Starting ChromeDriver 88.0.4324.96 (68dba2d8a0b149a1d3afac56fa74648032bcf46b-refs/branch-heads/4324@{#1784}) on port 5869
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
Feb 26, 2021 3:39:47 PM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
    Given I am in the wikipedia home page      # WikipediaStepDefinitions.iAmInTheWikipediaHomePage()
    When I search "Java"                       # WikipediaStepDefinitions.iAskWhetherItsFridayYet(String)
    Then I should see the article title "Java" # WikipediaStepDefinitions.iShouldBeTold(String)

  Scenario Outline: Search                     # ./src/test/java/hellocucumber/features/wikipedia_home_page.feature:24
Starting ChromeDriver 88.0.4324.96 (68dba2d8a0b149a1d3afac56fa74648032bcf46b-refs/branch-heads/4324@{#1784}) on port 43332
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
Feb 26, 2021 3:39:52 PM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
    Given I am in the wikipedia home page      # WikipediaStepDefinitions.iAmInTheWikipediaHomePage()
    When I search "Java"                       # WikipediaStepDefinitions.iAskWhetherItsFridayYet(String)
    Then I should see the article title "Java" # WikipediaStepDefinitions.iShouldBeTold(String)

  Scenario: Check Talk Tab title            # ./src/test/java/hellocucumber/features/wikipedia_home_page.feature:26
Starting ChromeDriver 88.0.4324.96 (68dba2d8a0b149a1d3afac56fa74648032bcf46b-refs/branch-heads/4324@{#1784}) on port 4161
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
Feb 26, 2021 3:39:58 PM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
    Given I am in the wikipedia home page   # WikipediaStepDefinitions.iAmInTheWikipediaHomePage()
    When I search "Java"                    # WikipediaStepDefinitions.iAskWhetherItsFridayYet(String)
    Then I should see the "Talk" tab        # WikipediaStepDefinitions.iShouldSeeTheTab(String)
    When I click on the Talk tab            # WikipediaStepDefinitions.iClickOnTheTalkTab()
    Then I should see the "Talk:Java" title # WikipediaStepDefinitions.iShouldSeeTheTitle(String)

5 Scenarios (5 passed)
16 Steps (16 passed)
0m28.224s

Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 28.704 sec

Results :

Tests run: 5, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  31.151 s
[INFO] Finished at: 2021-02-26T15:40:02-05:00
[INFO] ------------------------------------------------------------------------
</pre>
</details>
