### PR TITLE
YouTube scenarios added with POM and step definitions

### DIFF
--- a/src/main/java/com/selenium/training/pages/BasePage.java
+++ b/src/main/java/com/selenium/training/pages/BasePage.java
@@ -16,9 +16,9 @@ public abstract class BasePage {
     public BasePage(WebDriver webDriver) {
         PageFactory.initElements(webDriver, this);
         this.webDriver = webDriver;
-        this.webDriverWait = new WebDriverWait(webDriver, 10);
+        this.webDriverWait = new WebDriverWait(webDriver, 20);
         actionsBuilder = new Actions(getWebDriver());
-
+        this.webDriver.manage().window().maximize();
     }
 
     public WebDriver getWebDriver(){

--- a/src/main/java/com/selenium/training/pages/endava/EndavaHomePage.java
+++ b/src/main/java/com/selenium/training/pages/endava/EndavaHomePage.java
@@ -8,7 +8,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
-import java.util.List;
 
 public class EndavaHomePage extends BasePage {
 

--- a/src/main/java/com/selenium/training/pages/youtube/VideoPage.java
+++ b/src/main/java/com/selenium/training/pages/youtube/VideoPage.java
@@ -1,0 +1,46 @@
+package com.selenium.training.pages.youtube;
+
+import com.selenium.training.pages.BasePage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+public class VideoPage extends BasePage {
+
+    public VideoPage(WebDriver webDriver) {
+        super(webDriver);
+    }
+
+    @FindBy(className = "ytp-ad-skip-button")
+    private WebElement skipAdButton;
+
+    @FindBy(className = "ytp-time-current")
+    private WebElement currentTime;
+
+    @FindBy(className = "video-stream")
+    private WebElement videoContainer;
+
+    @FindBy(className = "ytp-play-button")
+    private WebElement playButton;
+
+
+    public void skipAd() {
+        getWebDriverWait().until(ExpectedConditions.elementToBeClickable(skipAdButton));
+        skipAdButton.click();
+    }
+
+    public void isVideoPlaying() {
+        getWebDriverWait().until(ExpectedConditions.invisibilityOfElementLocated(By.className("ytp-ad-text")));
+    }
+
+    public void pauseVideoAtTime(String time) {
+        getWebDriverWait().until(ExpectedConditions.textToBePresentInElement(currentTime, time));
+        videoContainer.click();
+    }
+
+    public void seePlayButton() {
+        getWebDriverWait().until(ExpectedConditions.visibilityOf(playButton));
+    }
+}

--- a/src/main/java/com/selenium/training/pages/youtube/YouTubeHomePage.java
+++ b/src/main/java/com/selenium/training/pages/youtube/YouTubeHomePage.java
@@ -1,0 +1,44 @@
+package com.selenium.training.pages.youtube;
+
+import com.selenium.training.pages.BasePage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class YouTubeHomePage extends BasePage {
+
+    public YouTubeHomePage(WebDriver webDriver) {
+        super(webDriver);
+        webDriver.get("https://www.youtube.com/");
+    }
+
+    @FindBy(css = "ytd-guide-section-renderer.style-scope")
+    private List<WebElement> sections;
+
+    @FindBy(id = "contents")
+    private WebElement videoItemsContainer;
+
+    public boolean isExpectedSectionItems(List<String> expectedItems){
+        List<WebElement> bestOfYouTubeSection = sections.stream()
+                .filter(x -> x.findElement(By.id("guide-section-title")).getText().equals("BEST OF YOUTUBE"))
+                .collect(Collectors.toList());
+        List<String> items = bestOfYouTubeSection.get(0).findElements(By.id("endpoint")).stream().map(WebElement::getText).collect(Collectors.toList());
+        return items.containsAll(expectedItems);
+    }
+
+    public VideoPage openVideo() throws InterruptedException {
+        List<WebElement> videoItems = videoItemsContainer.findElements(By.id("content"));
+        getWebDriverWait().until(ExpectedConditions.elementToBeClickable(videoItems.get(0)));
+        System.out.println(videoItems.get(0).getText());
+        videoItems.get(0).click();
+
+
+        Thread.sleep(5000);
+        return new VideoPage(getWebDriver());
+    }
+}

--- a/src/test/java/hellocucumber/RunCucumberTest.java
+++ b/src/test/java/hellocucumber/RunCucumberTest.java
@@ -6,7 +6,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
 
 @CucumberOptions(
         //dryRun = true,
-        tags = {"@Endava"},
+        tags = {"@YouTube"},
         plugin = {"pretty"},
         features = {"./src/test/java/hellocucumber/features"})
 public class RunCucumberTest extends AbstractTestNGCucumberTests {

--- a/src/test/java/hellocucumber/features/endava_home_page.feature
+++ b/src/test/java/hellocucumber/features/endava_home_page.feature
@@ -1,6 +1,6 @@
 @Endava
-Feature: ESPN Home Page
-  Validation on the ESPN Home Page
+Feature: Endava Home Page
+  Validation on the Endava Home Page
 
   Scenario: Check video controls
     Given I am in the Endava home page

--- a/src/test/java/hellocucumber/features/youtube_home_page.feature
+++ b/src/test/java/hellocucumber/features/youtube_home_page.feature
@@ -1,0 +1,22 @@
+@YouTube
+Feature: Youtube Home Page
+  Validation on the Youtube Home Page
+
+  Scenario: Check best of YouTube section
+    Given I am in the YouTube home page
+    Then I should see the following elements under best of YouTube section
+      | Music      |
+      | Sports     |
+      | Gaming     |
+      | News       |
+      | Live       |
+      | Learning   |
+      | 360° Video |
+
+  Scenario: Open video
+    Given I am in the YouTube home page
+    When I open a video
+    And I skip the video ad
+    Then I should see the video playing
+    When I pause the video in time "0:02"
+    Then I should see the play button

--- a/src/test/java/hellocucumber/stepDefinitions/YouTubeStepDefinitions.java
+++ b/src/test/java/hellocucumber/stepDefinitions/YouTubeStepDefinitions.java
@@ -1,0 +1,51 @@
+package hellocucumber.stepDefinitions;
+
+import com.selenium.training.pages.youtube.VideoPage;
+import com.selenium.training.pages.youtube.YouTubeHomePage;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import org.testng.Assert;
+
+import java.util.List;
+
+public class YouTubeStepDefinitions {
+
+    private YouTubeHomePage youTubeHomePage;
+    private VideoPage videoPage;
+
+    @Given("I am in the YouTube home page")
+    public void iAmInTheYouTubeHomePage() {
+        youTubeHomePage = new YouTubeHomePage(BaseTest.getMyDriver().getWebDriver());
+    }
+
+    @Then("I should see the following elements under best of YouTube section")
+    public void iShouldSeeTheFollowingElementsUnderBestOfYouTubeSection(List<String> items) {
+        Assert.assertTrue(youTubeHomePage.isExpectedSectionItems(items));
+    }
+
+    @When("I open a video")
+    public void iOpenAVideo() throws InterruptedException {
+        videoPage = youTubeHomePage.openVideo();
+    }
+
+    @When("I skip the video ad")
+    public void iSkipTheVideoAd() {
+        videoPage.skipAd();
+    }
+
+    @Then("I should see the video playing")
+    public void iShouldSeeTheVideoPlaying() {
+        videoPage.isVideoPlaying();
+    }
+
+    @When("I pause the video in time {string}")
+    public void iPauseTheVideoInTime(String time) {
+        videoPage.pauseVideoAtTime(time);
+    }
+
+    @Then("I should see the play button")
+    public void iShouldSeeThePlayButton() {
+        videoPage.seePlayButton();
+    }
+}


### PR DESCRIPTION
## DESCRIPTION
- YouTube scenarios with step definitions and POM implementation

## PR CHECKLIST
- [x] PR title has description.
- [x] Review Complete.
- [x] All Evidence Attached.

## CONSIDERATIONS

## TESTING INSTRUCTIONS
mvn install
mvn test
## EVIDENCE

<details>
<summary>Click here to see evidence</summary>
<pre>
   -------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running TestSuite
Configuring TestNG with: org.apache.maven.surefire.testng.conf.TestNG652Configurator@7b0070
@YouTube
Feature: Youtube Home Page
  Validation on the Youtube Home Page

  @YouTube
  Scenario: Check best of YouTube section                                  # ./src/test/java/hellocucumber/features/youtube_home_page.feature:5
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Starting ChromeDriver 88.0.4324.96 (68dba2d8a0b149a1d3afac56fa74648032bcf46b-refs/branch-heads/4324@{#1784}) on port 4172
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
Mar 04, 2021 12:38:44 PM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
    Given I am in the YouTube home page                                    # YouTubeStepDefinitions.iAmInTheYouTubeHomePage()
    Then I should see the following elements under best of YouTube section # YouTubeStepDefinitions.iShouldSeeTheFollowingElementsUnderBestOfYouTubeSection(String>)
./src/test/java/hellocucumber/features/youtube_home_page.feature:5
[5]
PASSED
Check best of YouTube section
[@YouTube]

  @YouTube
  Scenario: Open video                    # ./src/test/java/hellocucumber/features/youtube_home_page.feature:16
Starting ChromeDriver 88.0.4324.96 (68dba2d8a0b149a1d3afac56fa74648032bcf46b-refs/branch-heads/4324@{#1784}) on port 21661
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
Mar 04, 2021 12:38:50 PM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
    Given I am in the YouTube home page   # YouTubeStepDefinitions.iAmInTheYouTubeHomePage()
BAD BUNNY x ROSAL═A - LA NOCHE DE ANOCHE (Video Oficial)
Bad Bunny
100M views
2 weeks ago
    When I open a video                   # YouTubeStepDefinitions.iOpenAVideo()
    And I skip the video ad               # YouTubeStepDefinitions.iSkipTheVideoAd()
    Then I should see the video playing   # YouTubeStepDefinitions.iShouldSeeTheVideoPlaying()
    When I pause the video in time "0:02" # YouTubeStepDefinitions.iPauseTheVideoInTime(String)
    Then I should see the play button     # YouTubeStepDefinitions.iShouldSeeThePlayButton()
./src/test/java/hellocucumber/features/youtube_home_page.feature:16
[16]
PASSED
Open video
[@YouTube]

2 Scenarios (2 passed)
8 Steps (8 passed)
0m33.882s

Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 34.475 sec

Results :

Tests run: 2, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  36.452 s
[INFO] Finished at: 2021-03-04T12:39:15-05:00
[INFO] ------------------------------------------------------------------------
</pre>
</details>
